### PR TITLE
V1.1.1 beta

### DIFF
--- a/get-dependency-versions.sh
+++ b/get-dependency-versions.sh
@@ -1,6 +1,53 @@
 #!/usr/bin/env bash
 set -e
 
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to install missing dependencies
+install_dependencies() {
+    local missing_deps=()
+    
+    # Check for required dependencies
+    if ! command_exists curl; then
+        missing_deps+=("curl")
+    fi
+    
+    if ! command_exists jq; then
+        missing_deps+=("jq")
+    fi
+    
+    # Install missing dependencies if any
+    if [ ${#missing_deps[@]} -gt 0 ]; then
+        echo "Missing dependencies: ${missing_deps[*]}"
+        echo "Installing missing dependencies..."
+        
+        # Detect package manager and install
+        if command_exists apt-get; then
+            sudo apt-get update
+            sudo apt-get install -y "${missing_deps[@]}"
+        elif command_exists yum; then
+            sudo yum install -y "${missing_deps[@]}"
+        elif command_exists dnf; then
+            sudo dnf install -y "${missing_deps[@]}"
+        elif command_exists pacman; then
+            sudo pacman -S --noconfirm "${missing_deps[@]}"
+        elif command_exists brew; then
+            brew install "${missing_deps[@]}"
+        else
+            echo "ERROR: No supported package manager found. Please install manually: ${missing_deps[*]}"
+            exit 1
+        fi
+        
+        echo "Dependencies installed successfully!"
+    fi
+}
+
+# Check and install dependencies
+install_dependencies
+
 # Use first argument as Cardano node version, or default to 10.5.1 if not provided
 CARDANO_NODE_VERSION="${1:-10.5.1}"
 

--- a/love2automate-ada-terminalapp/CardanoNodeManager.csproj
+++ b/love2automate-ada-terminalapp/CardanoNodeManager.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>love2automate-ada</AssemblyName>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 

--- a/love2automate-ada-terminalapp/Program.cs
+++ b/love2automate-ada-terminalapp/Program.cs
@@ -35,10 +35,6 @@ public class Program
         var uninstallOption = new Option<bool>(new[] { "--uninstall", "-u" }, "Uninstall Cardano node components");
         rootCommand.AddOption(uninstallOption);
 
-        // Upgrade option (COMMENTED OUT - NOT TESTED YET)
-        // var upgradeOption = new Option<bool>(new[] { "--upgrade", "-g" }, "Upgrade Cardano node components");
-        // rootCommand.AddOption(upgradeOption);
-
         // Status option
         var statusOption = new Option<bool>(new[] { "--status", "-s" }, "Check status of Cardano node");
         rootCommand.AddOption(statusOption);
@@ -137,18 +133,7 @@ public class Program
             }
             return await HandleUninstall(target);
         }
-        // UPGRADE FUNCTIONALITY COMMENTED OUT - NOT TESTED YET
-        /*
-        else if (upgrade)
-        {
-            if (string.IsNullOrEmpty(target))
-            {
-                Console.WriteLine("Target is required for upgrade operation. Available targets: cardano-node");
-                return 1;
-            }
-            return await HandleUpgrade(target);
-        }
-        */
+
         else if (status)
             return await HandleStatus();
         else if (setup)
@@ -183,6 +168,10 @@ public class Program
                 await StoreInstallationConfig(port);
             }
             
+            Console.WriteLine();
+            Console.WriteLine("⚠️  IMPORTANT: You MUST restart your terminal or run 'source ~/.bashrc' for PATH changes to take effect.");
+            Console.WriteLine();
+
             return result;
         }
         
@@ -211,35 +200,6 @@ public class Program
         Console.WriteLine("Available targets: cardano-node");
         return 1;
     }
-
-    // UPGRADE FUNCTIONALITY COMMENTED OUT - NOT TESTED YET
-    /*
-    private static async Task<int> HandleUpgrade(string target)
-    {
-        Console.WriteLine($"Upgrading {target}...");
-        
-        // Check prerequisites before proceeding
-        var prereqCheck = await CheckPrerequisites();
-        if (prereqCheck != 0)
-        {
-            return prereqCheck;
-        }
-        
-        if (target.ToLower() == "cardano-node")
-        {
-            Console.WriteLine("Upgrade functionality will execute upgrade steps...");
-            // For upgrade, we might want to run specific upgrade playbooks
-            Console.WriteLine("Note: Upgrade steps are available in upgrade-steps/ directory");
-            Console.WriteLine("Consider implementing specific upgrade playbook execution here");
-            return 0;
-        }
-        
-        Console.WriteLine($"Unknown target: {target}");
-        Console.WriteLine("Available targets: cardano-node");
-        return 1;
-    }
-    */
-
     private static async Task<int> HandleStatus()
     {
         Console.WriteLine("Checking Cardano node status...");


### PR DESCRIPTION
- Resolved an issue where dependency versions could not fetched because ```curl``` and ```jq``` were not installed
- Resolved an issue where users could not run Cardano Node because environment variables weren't being used - added a prompt message to run ```source ~/.bashrc```.